### PR TITLE
Purge pandas pytable pickle performance warning when running checkCompass.sh

### DIFF
--- a/tests/check.py
+++ b/tests/check.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
 
         idx = len(df.index)
         df.loc[idx, "Test name"] = param_file.split('/')[-1]
-        df.loc[idx, "Init"] = is_init
-        df.loc[idx, "SR@100iter"] = SR
+        df.loc[idx, "Init"] = str(is_init)
+        df.loc[idx, "SR@100iter"] = str(SR)
 
         df.to_hdf("check.h5", "check")


### PR DESCRIPTION
**Problem:**
On running ./checkCompass.sh , for each test case the following performance warning is thrown

```
/site-packages/pandas/core/generic.py:2431: PerformanceWarning: 
your performance may suffer as PyTables will pickle object types that it cannot
map directly to c-types [inferred_type->mixed,key->block0_values] [items->Index(['Test name', 'Init', 'SR@100iter'], dtype='object')]

  pytables.to_hdf(
```

This seems to stem from the fact that rows in the dataframe contain mixed data types, which then will be considered of the generic type object. Obviously, performance isn't an issue here, but getting rid of the warning would improve the textual output.

**Proposed Solution**
As the check.h5 file seems to be only used for the output of the test results at the end of checkCompass.sh, simply converting the boolean Init, and the float/string SR@100Iter to a string solves the problem.