### PR TITLE
Refine design of SAXO stage to simulate real SAXO performance

### DIFF
--- a/shesha/constants.py
+++ b/shesha/constants.py
@@ -188,6 +188,7 @@ class ApertureType:
     EELT_CUSTOM = 'EELT-Custom'
     VLT = 'VLT'
     KECK = 'keck'
+    VLT_NOOBS = 'VLT-NoObs'
 
 
 class SpiderType:

--- a/shesha/init/geom_init.py
+++ b/shesha/init/geom_init.py
@@ -269,8 +269,9 @@ def init_wfs_size(p_wfs: conf.Param_wfs, r0: float, p_tel: conf.Param_tel, verbo
     else:
         pdiam = p_wfs._pdiam
         # this case is for a wfs with fixed # of phase points
-        Nfft = util.fft_goodsize(2 * pdiam)
-    # size of the support in fourier domain
+        # Change to 4* pdiam for SAXO/SAXO+ simulations, instead of usual 2* pdiam in COMPASS
+        Nfft = util.fft_goodsize(4 * pdiam)
+        # size of the support in fourier domain
 
     # qpixsize = pdiam * \
     #     (p_wfs.Lambda * 1.e-6) / subapdiam * CONST.RAD2ARCSEC / Nfft
@@ -823,8 +824,10 @@ def init_sh_geom(p_wfs: conf.Param_wfs, r0: float, p_tel: conf.Param_tel,
         (p_tel.diam / np.sqrt(p_wfs.nxsub ** 2. + (dr0 / 1.5) ** 2.)) / 4.848
     kernelfwhm = np.sqrt(fwhmseeing**2. + p_wfs.kernel**2.)
 
+    # C. Bechet / F. Ferreira : Fix for SAXO+ project to improve SH WFS response
+    # fix consists in multiplying tmp below by 0
     tmp = util.makegaussian(p_wfs._Ntot, kernelfwhm / p_wfs._qpixsize, p_wfs._Ntot // 2,
-                            p_wfs._Ntot // 2).astype(np.float32)
+                            p_wfs._Ntot // 2).astype(np.float32)*0
 
     tmp = np.roll(tmp, tmp.shape[0] // 2, axis=0)
     tmp = np.roll(tmp, tmp.shape[1] // 2, axis=1)

--- a/shesha/supervisor/saxoPlusManager.py
+++ b/shesha/supervisor/saxoPlusManager.py
@@ -122,7 +122,7 @@ class SaxoPlusManager():
         self.first_stage.computeCoroImage = False
         self.second_stage.computeCoroImage = False
 
-    def next(self, seeAtmos=True):
+    def next(self):
         """
         MAIN method that allows to manage properly the 2 AO stages of SAXO+ system. 
         The phase residuals (including turbulence + AO loop residuals) of the first stage simulation is sent to second stage simulation
@@ -135,12 +135,11 @@ class SaxoPlusManager():
         # Iteration time of the first stage is set as the same as the second stage to allow
         # correct atmosphere movement for second stage integration. Then, first stage as to compute
         # every 3 iteration to be 3 times slower than the second stage
-        # self.first_stage.atmos.enable_atmos(seeAtmos) #Enabling (or not) Turbulence
         self.second_stage.atmos.enable_atmos(False) # Turbulence always disabled on 2nd instance of COMPASS
         if not (self.iterations % self.frequency_ratio): # Time for first stage full computation: We update the first stage command every frequency_ratio iterations. 
             self.first_stage.next()
         else: # Only raytracing current tubulence phase (if any) and current DMs phase (no command updates). 
-            self.first_stage.next(do_control=False, apply_control=False, compute_tar_psf=False)
+            self.first_stage.next(do_control=False, apply_control=False, compute_tar_psf=True)
         # Get residual of first stage to put it into second stage
         # For now, involves GPU-CPU memory copies, can be improved later if speed is a limiting factor here... 
         first_stage_residual = self.first_stage.target.get_tar_phase(0)

--- a/shesha/util/make_pupil.py
+++ b/shesha/util/make_pupil.py
@@ -110,6 +110,10 @@ def make_pupil(dim, pupd, tel, xc=-1, yc=-1, real=0, halfSpider=False):
         tel.set_cobs(0.14)
         print("force_VLT_pup_cobs = %5.3f" % 0.14)
         return make_VLT(dim, pupd, tel)
+    elif tel.type_ap == ApertureType.VLT_NOOBS:
+        tel.set_cobs(0.)
+        print("Remove central obstruction to the VLT")
+        return make_VLT(dim, pupd, tel)
     elif tel.type_ap == ApertureType.GENERIC:
         return make_pupil_generic(dim, pupd, tel.t_spiders, tel.spiders_type, xc, yc,
                                   real, tel.cobs)


### PR DESCRIPTION
- add a VLT-NoObs Aperture type in order to simulate SAXO existing calibration conditions (constants.py and make_pupil.py affected).
- in geom_init.py, modified FFT size restriction for SAXO with a factor 4 instead of 2, to guarantee detector pixel representative of SAXO system.
- in geom_init.py, add the temporary fix with tmp*0 on the centroiding convolution, to get proper centroiding scaling units.
- in saxoPlusManager.py, remove the seeAtmos keyword since it was not used. Atmos must be enabled/disabled outside of the next method.
- in saxoPlusManager.py, the target PSF is now measured at the intersampling (highest) frequency, in order to guarantee consistent comparison between SAXO and SAXO+ stages performance.