### PR TITLE
Fix for updated numpy cast rules using *=

### DIFF
--- a/shesha/util/make_pupil.py
+++ b/shesha/util/make_pupil.py
@@ -619,7 +619,7 @@ def generateEeltPupilMask(npt, dspider, i0, j0, pixscale, gap, rotdegree, D=40.0
         obstru = (util.dist(pup.shape[0], pup.shape[0] // 2 + 0.5,
                             pup.shape[0] // 2 + 0.5) >=
                   (pup.shape[0] * cobs + 1.) * 0.5).astype(np.float32)
-        pup *= obstru
+        pup = pup * obstru
     return pup
 
 


### PR DESCRIPTION
In recent numpy versions, the operation `pup *= obstru` complains with
`numpy.core._exceptions.UFuncTypeError: Cannot cast ufunc 'multiply' output from dtype('float32') to dtype('bool') with casting rule 'same_kind'`, using `pup = pup * obstru` avoids that.
