### PR TITLE
Update check.py

### DIFF
--- a/tests/check.py
+++ b/tests/check.py
@@ -121,4 +121,4 @@ if __name__ == "__main__":
         df.loc[idx, "SR@100iter"] = str(SR)
         df.loc[idx, "T Loop"] = str(t_loop)
 
-        df.to_hdf("check.h5", "check")
+        df.to_hdf("check.h5", key="check")


### PR DESCRIPTION
Pandas gives a *FutureWarning* about keyword-only arguments when running `./tests/check_compass.py`. I added the keyword to the function call in `tests/check.py`.

Previous output:
```
[1/27] running test_custom_dm
/home/ultimate-rts/src/shesha/tests/check.py:124: FutureWarning: Starting with pandas version 3.0 all arguments of to_hdf except for the argument 'path_or_buf' will be keyword-only.
  df.to_hdf("check.h5", "check")
[2/27] running test_custom_dm_diam_dm
/home/ultimate-rts/src/shesha/tests/check.py:124: FutureWarning: Starting with pandas version 3.0 all arguments of to_hdf except for the argument 'path_or_buf' will be keyword-only.
  df.to_hdf("check.h5", "check")
...
| 24 | test_sh_mv.py                  | True   |     0.750612 |        0 | 0.0700118 |
| 25 | test_sh_tcog.py                | True   |     0.716789 |        0 | 0.0594273 |
| 26 | test_sh_wcog.py                | True   |     0.662501 |        0 | 0.0600561 |
```

New output:
```
[1/27] running test_custom_dm
[2/27] running test_custom_dm_diam_dm
...
| 24 | test_sh_mv.py                  | True   |     0.750612 |        0 | 0.0679511 |
| 25 | test_sh_tcog.py                | True   |     0.716789 |        0 | 0.0771192 |
| 26 | test_sh_wcog.py                | True   |     0.662501 |        0 | 0.0597021 |
```